### PR TITLE
Fix small spelling mistakes in documentation

### DIFF
--- a/docs/en/source/hardware/getting_started/assemble.md
+++ b/docs/en/source/hardware/getting_started/assemble.md
@@ -16,20 +16,20 @@ If you'd rather skip the fun of tightening screws, you can also buy [pre-assembl
 > If you already have 2x SO101 arms assembled with motors configured, skip.
 >
 
-- Build 2x SO101 arms by following [SO101 Step-by-Step Assembly Instructions](https://huggingface.co/docs/lerobot/so101) to build 2 identical follower arms with 2 sets of motors (both preivous indexed as 1-6) for 2 control boards.
+- Build 2x SO101 arms by following [SO101 Step-by-Step Assembly Instructions](https://huggingface.co/docs/lerobot/so101) to build 2 identical follower arms with 2 sets of motors (both previous indexed as 1-6) for 2 control boards.
 - Then continue to [configure the motors](https://huggingface.co/docs/lerobot/so101#configure-the-motors) for the SO101 arms. 
 - Follow this [installation guide](https://github.com/TheRobotStudio/SO-ARM100/tree/main/Optional/SO101_Wrist_Cam_Hex-Nut_Mount_32x32_UVC_Module) to add wrist cameras.
 - If you have [3M gripper tape](https://www.amazon.com/gp/product/B0093CQPW8/ref=ppx_yo_dt_b_search_asin_title?ie=UTF8&psc=1), now it's time to wrap it on the fingers.
 
 
-## 🤔 Conigure Motors
+## 🤔 Configure Motors
 
 ![image](https://github.com/user-attachments/assets/fc674d38-d703-40bd-87a2-a502af1b52c7)
 
 > Since the official lerobot codebase currently doesn't support motor configuring besides the arm, we use [Bambot](https://bambot.org/) instead (works on Windows and Mac, Linux needs 'sudo chmod 666 /dev/ttyACM0' first).
 >
 
-- Connect the motor you want to configure (one-by-one) to a control board, and directly connect tohe board to your computer. 
+- Connect the motor you want to configure (one-by-one) to a control board, and directly connect the board to your computer. 
 - Navigate to [the motor configuration page of Bambot](https://bambot.org/feetech.js), establish the connection and scan for your servo motor.
   ![image](https://github.com/user-attachments/assets/89eb4674-e26e-4edc-9943-ad5c0d4516ec)
 
@@ -49,7 +49,7 @@ If you'd rather skip the fun of tightening screws, you can also buy [pre-assembl
 
 ## 🧑‍🦼‍➡ Wheel Base
 
-> If you already have a Lekiwi base, distach the battery, servo mounts, etc. Base plate will only have 3 mounted motors with wheels (keep the wirings).
+> If you already have a Lekiwi base, detach the battery, servo mounts, etc. Base plate will only have 3 mounted motors with wheels (keep the wirings).
 >
 
 ![image](https://github.com/user-attachments/assets/4599c9d0-3ce3-40e8-9a8e-d21e1e5feb01)
@@ -80,7 +80,7 @@ Put the Lekiwi base with the connectors under the cart to see whether it can giv
 
 
 ```{tip}
-Filp the cart over to do the assembly below.
+Flip the cart over to do the assembly below.
 ```
 
 - Now install the Lekiwi base with the connectors onto the bottom of the IKEA cart, with the thinner plate on the other side.
@@ -103,7 +103,7 @@ This new hardware version is compatible with the IKEA cart metal mesh, and all t
 ![image](https://github.com/user-attachments/assets/1ea61764-6e4c-4edf-8d0f-0979430a7921)
 
 
-- Easier assembly when the base is filpped over.
+- Easier assembly when the base is flipped over.
 
 ### Head Assembly
 
@@ -133,7 +133,7 @@ When extending the 5264 wire yourself, be careful with the polarity—reversed c
 
 ### 🔋 Place the Battery 🛒
 
-- Anywhere you like on the middle or lower level of the cart to maintain a low center of mass. The battery has an anti-slip bottom so it won't easily silde during normal operations.
+- Anywhere you like on the middle or lower level of the cart to maintain a low center of mass. The battery has an anti-slip bottom so it won't easily slide during normal operations.
 - Maintain placed upright for safety.
 - Just in case you also accidentally throw the battery manual away, [here it is](https://github.com/Vector-Wangel/XLeRobot/blob/main/others/Manual_Anker_SOLIX_C300_DC_Portable_Power_Station.pdf).
 

--- a/docs/en/source/hardware/getting_started/material.md
+++ b/docs/en/source/hardware/getting_started/material.md
@@ -3,14 +3,14 @@
 ## 💵 Total Cost 
 
 ```{note}
-Doesn't include cost of 3D printing, tools, shippings and taxes.
+Doesn't include cost of 3D printing, tools, shipping and taxes.
 ```
 
 | Price | US | EU | CN |
 | --- | --- | --- | --- |
 | **Basic** (use your laptop, single RGB head cam) | **~$660** | **~€680** | **~¥3999** |
 | ↑ Stereo dual-eye RGB head cam | +$30 | +€30 | +¥199 |
-| + RasberryPi | +$79 | +€79 | +¥399 |
+| + RaspberryPi | +$79 | +€79 | +¥399 |
 | ↑ RealSense RGBD head cam | +$220 | +€230 | +¥1499 |
 
 
@@ -51,7 +51,7 @@ Skip this section if you already have these tools:
 
 ![image](https://github.com/user-attachments/assets/ee012d47-f2a9-495c-a156-01bf92b2e63b)
 
-- XLeRobot is designed to be pratical, which is why it only comes in a 12V version. You can also purchase for [STS3250 servo](https://shop.wowrobo.com/products/feetech-sts3250-c002-servo-12v-50kg-1-345-servo) (1.5x torque, 3x price) for extreme performance.
+- XLeRobot is designed to be practical, which is why it only comes in a 12V version. You can also purchase for [STS3250 servo](https://shop.wowrobo.com/products/feetech-sts3250-c002-servo-12v-50kg-1-345-servo) (1.5x torque, 3x price) for extreme performance.
 - 17 motors = 12 for arms + 3 for base + 2 for head.
 - Any battery/power bank/power station that supports two 60W+ USB-C fast charging should work. Here are some other potential options (not tested), these brands should be available both in US and China.
   - [UGREEN 300W 48000mAh Power Bank](https://www.ugreen.com/products/ugreen-300w-48000mah-portable-charger-power-bank?gad_source=1&gad_campaignid=22334559506&gbraid=0AAAAAokPG3uYEJ4xHLZ1A5FoS_1cCYYRO&gclid=CjwKCAjwq9rFBhAIEiwAGVAZP_WRyKyLoZsEkLylqFw3KlfsLzoJ5NMiHtnRrRCAHs69uGl3R8McnBoCL-gQAvD_BwE)
@@ -89,7 +89,7 @@ Skip this section if you already have these tools:
 
 ![image](https://github.com/user-attachments/assets/0f5a10ce-d0e9-4e53-b457-27a9ba057cbf)
 
-## 🧑‍🤝‍🧑 Alternative chioces 
+## 🧑‍🤝‍🧑 Alternative choices 
 
 - **IKEA Cart**: You can use a similar cart not from IKEA; however, this may require minor adjustments to the base connector in [3D printed parts](https://github.com/Vector-Wangel/XLeRobot/tree/main/hardware).
 - **Batteries**: You can use **other batteries**, but ensure the maximum output capacity can adequately power 2 arms and 3 wheels(~120W=60W*2 ports) (and a RaspberryPi (40W) if you have one).

--- a/docs/en/source/hardware/hardware_intro/index.md
+++ b/docs/en/source/hardware/hardware_intro/index.md
@@ -2,7 +2,7 @@
 
 **XLeRobot** = Lekiwi + 1x SO-100/SO-101 arm + **IKEA RÅSKOG Cart** + **Anker Battery**
 
-= 2x SO-100/SO-101 Arms + 3x omni wheels + RasberryPi + **IKEA RÅSKOG Cart** + **Anker Battery**
+= 2x SO-100/SO-101 Arms + 3x omni wheels + RaspberryPi + **IKEA RÅSKOG Cart** + **Anker Battery**
 
 #### 📜Basic Specs
 
@@ -12,7 +12,7 @@
     - Width range: ~0.36m from the cart edge.
     - Capable of many household tasks.
 - **Battery**🔋:
-    - 300W max out: sufficient for powering 12V version dual arm + lekiwi base + RasberryPi (~180W max)
+    - 300W max out: sufficient for powering 12V version dual arm + lekiwi base + RaspberryPi (~180W max)
     - 288Wh capacity: can normally operate for 10hrs+
     - 280W max in: 1hr to get fully charged
     - Optional solar panels☀: for endless recharging

--- a/docs/en/source/hardware/index.md
+++ b/docs/en/source/hardware/index.md
@@ -9,7 +9,7 @@
 | --- | --- | --- | --- |
 | **Basic** (use your laptop, single RGB head cam) | **~$660** | **~€680** | **~¥3999** |
 | ↑ Stereo dual-eye RGB head cam | +$30 | +€30 | +¥199 |
-| + RasberryPi | +$79 | +€79 | +¥399 |
+| + RaspberryPi | +$79 | +€79 | +¥399 |
 | ↑ RealSense RGBD head cam | +$220 | +€230 | +¥1499 |
 
 

--- a/docs/en/source/index.md
+++ b/docs/en/source/index.md
@@ -56,7 +56,7 @@ Assembly kit ready for purchase soon, stay tuned!
 Supports for multiple sensors (depth, segmentation, tactile, etc), RL/IL/VLA environments. Get started in 15 min.
 -  ![vr](https://github.com/user-attachments/assets/68b77bea-fdcf-4f42-9cf0-efcf1b188358)
 
-- 2025-07-01: [**Documentation** website](https://xlerobot.readthedocs.io/en/latest/index.html) out for more orgainized turotials, demos and resources.
+- 2025-07-01: [**Documentation** website](https://xlerobot.readthedocs.io/en/latest/index.html) out for more organized tutorials, demos and resources.
 
 - 2025-06-13: [**XLeRobot 0.2.0**](https://xlerobot.readthedocs.io) hardware setup fully capable for household tasks, with 660$ cost. 
 

--- a/docs/en/source/index.md
+++ b/docs/en/source/index.md
@@ -67,7 +67,7 @@ Supports for multiple sensors (depth, segmentation, tactile, etc), RL/IL/VLA env
 | --- | --- | --- | --- |
 | **Basic** (use your laptop, single RGB head cam) | **~$660** | **~€680** | **~¥3999** |
 | ↑ Stereo dual-eye RGB head cam | +$30 | +€30 | +¥199 |
-| + RasberryPi | +$79 | +€79 | +¥399 |
+| + RaspberryPi | +$79 | +€79 | +¥399 |
 | ↑ RealSense RGBD head cam | +$220 | +€230 | +¥1499 |
 
 Assembly kit ready for purchase soon, stay tuned!

--- a/docs/en/source/simulation/getting_started/index.md
+++ b/docs/en/source/simulation/getting_started/index.md
@@ -107,7 +107,7 @@ Put the XLeRobot files into Maniskill folders:
 #### Get Moving
 
 ```{note}
-Change shader="default" to "rt-fast" for photo-realisitic ray-tracing rendering (but slower).
+Change shader="default" to "rt-fast" for photo-realistic ray-tracing rendering (but slower).
 ```
 
 ##### Joint Control

--- a/docs/en/source/software/index.md
+++ b/docs/en/source/software/index.md
@@ -23,7 +23,7 @@ Suggested to test single arm teleop first
 All example scripts are located in the [`software/examples/`](https://github.com/Vector-Wangel/XLeRobot/tree/main/software/examples) directory and can be run directly after proper setup and calibration.
 
 ```{note}
-For basic version of XLeRobot, you don't need a RasberryPi. Just use your laptop, and put it in the IKEA cart if you want to use the full system.
+For basic version of XLeRobot, you don't need a RaspberryPi. Just use your laptop, and put it in the IKEA cart if you want to use the full system.
 ```
 
 ## XLeRobot Full System Control
@@ -76,11 +76,11 @@ YOLO-powered object detection and tracking system. Run `3_so100_yolo_ee_control.
 To test the single-arm version of XLeRobot with Lekiwi codes, you should detach the SO101 arm that doesn't share the same motor control board with the base, clamp it on your table and connect it to your PC to act as the leader arm.
 ```
 ```{note}
-For mobile base version, you need a RasberryPi in advance.
+For mobile base version, you need a RaspberryPi in advance.
 ```
 
 Follow all of their [software instructions](https://github.com/huggingface/lerobot/blob/main/examples/11_use_lekiwi.md#b-install-software-on-pi) so you can:
--  [Install software on RasberryPi](https://github.com/huggingface/lerobot/blob/main/examples/11_use_lekiwi.md#b-install-software-on-pi) and setup SSH 
+-  [Install software on RaspberryPi](https://github.com/huggingface/lerobot/blob/main/examples/11_use_lekiwi.md#b-install-software-on-pi) and setup SSH 
 -  [Install LeRobot on PC](https://github.com/huggingface/lerobot/blob/main/examples/11_use_lekiwi.md#c-install-lerobot-on-laptop)
 -  [Update config](https://github.com/huggingface/lerobot/blob/main/examples/11_use_lekiwi.md#update-config)
 -  [Calibrate](https://github.com/huggingface/lerobot/blob/main/examples/11_use_lekiwi.md#e-calibration)


### PR DESCRIPTION
Fixes a few small typos and corrects "RasberryPi" to "RaspberryPi"