### PR TITLE
Fixed the scene xml file path.

### DIFF
--- a/simulation/mujoco/xlerobot_mujoco.py
+++ b/simulation/mujoco/xlerobot_mujoco.py
@@ -246,7 +246,7 @@ class XLeRobotController:
 
 def main():
     try:
-        mjcf_path = "../scene.xml"
+        mjcf_path = "scene.xml"
         controller = XLeRobotController(mjcf_path)
         controller.run()
     except KeyboardInterrupt:


### PR DESCRIPTION
The relative path does not need "../" following the README where the run cmd is `python xlerobot_mujoco.py` in the mujoco directory.