### PR TITLE
fix(docs): remove extra backslash in demo command

### DIFF
--- a/docs/en/source/simulation/getting_started/index.md
+++ b/docs/en/source/simulation/getting_started/index.md
@@ -50,7 +50,7 @@ Change shader="rt-fast" to "default" for faster rendering or if your computer do
 ```
 
 ```bash
-python -m mani_skill.examples.demo_random_action -e "ReplicaCAD_SceneManipulation-v1" \\
+python -m mani_skill.examples.demo_random_action -e "ReplicaCAD_SceneManipulation-v1" \
   --render-mode="human" --shader="rt-fast"
 
 ```

--- a/docs/zh/source/simulation/getting_started/index.md
+++ b/docs/zh/source/simulation/getting_started/index.md
@@ -50,7 +50,7 @@ python -m mani_skill.utils.download_asset "ReplicaCAD"
 ```
 
 ```bash
-python -m mani_skill.examples.demo_random_action -e "ReplicaCAD_SceneManipulation-v1" \\
+python -m mani_skill.examples.demo_random_action -e "ReplicaCAD_SceneManipulation-v1" \
   --render-mode="human" --shader="rt-fast"
 
 ```


### PR DESCRIPTION
The demo command in README had an extra backslash, which caused execution errors. This PR removes the redundant backslash.