### PR TITLE
fix(docs): Correct command for the VR control demo

### DIFF
--- a/docs/en/source/simulation/getting_started/vr_sim.md
+++ b/docs/en/source/simulation/getting_started/vr_sim.md
@@ -60,11 +60,12 @@ python vr_monitor.py
 For ManiSkill environments, run:
 
 ```bash
-python -m mani_skill.examples.XLeRobot_demo_VR_ee_ctrl \
+python -m mani_skill.examples.demo_ctrl_action_ee_VR \
     -e "ReplicaCAD_SceneManipulation-v1" \
     --render-mode="human" \
     --shader="rt-fast" \
-    -c "pd_joint_delta_pos_dual_arm"
+    -c "pd_joint_delta_pos_dual_arm" \
+    -r "xlerobot"
 ```
 
 - `-e` sets the environment (e.g., `ReplicaCAD_SceneManipulation-v1`, AI2THOR, Robocasa, etc.)

--- a/docs/zh/source/simulation/getting_started/vr_sim.md
+++ b/docs/zh/source/simulation/getting_started/vr_sim.md
@@ -60,11 +60,12 @@ python vr_monitor.py
 对于ManiSkill环境，运行：
 
 ```bash
-python -m mani_skill.examples.XLeRobot_demo_VR_ee_ctrl \
+python -m mani_skill.examples.demo_ctrl_action_ee_VR \
     -e "ReplicaCAD_SceneManipulation-v1" \
     --render-mode="human" \
     --shader="rt-fast" \
-    -c "pd_joint_delta_pos_dual_arm"
+    -c "pd_joint_delta_pos_dual_arm" \
+    -r "xlerobot"
 ```
 
 - `-e` 设置环境 (例如, `ReplicaCAD_SceneManipulation-v1`, AI2THOR, Robocasa等)


### PR DESCRIPTION
The command provided in the documentation for running the VR control demo was incorrect. It pointed to a non-existent module, `mani_skill.examples.XLeRobot_demo_VR_ee_ctrl`, which caused the
`No module named mani_skill.examples.XLeRobot_demo_VR_ee_ctrl` error.

This commit updates the command to use the correct module, `mani_skill.examples.demo_ctrl_action_ee_VR`, and adds the required `-r "xlerobot"` argument to specify the robot.

The corrected command now runs successfully.

Before:
```bash
python -m mani_skill.examples.XLeRobot_demo_VR_ee_ctrl \
    -e "ReplicaCAD_SceneManipulation-v1" \
    --render-mode="human" \
    --shader="rt-fast" \
    -c "pd_joint_delta_pos_dual_arm"
```

After:
```bash
python -m mani_skill.examples.demo_ctrl_action_ee_VR \
    -e "ReplicaCAD_SceneManipulation-v1" \
    --render-mode="human" \
    --shader="rt-fast" \
    -c "pd_joint_delta_pos_dual_arm" \
    -r "xlerobot"
```

Related to issue #56