### PR TITLE
fix function name error

### DIFF
--- a/software/examples/4_xlerobot_teleop_keyboard.py
+++ b/software/examples/4_xlerobot_teleop_keyboard.py
@@ -404,7 +404,7 @@ def main():
         print(robot)
         return
         
-    _init_rerun(session_name="xlerobot_teleop_v2")
+    init_rerun(session_name="xlerobot_teleop_v2")
 
     #Init the keyboard instance
     keyboard_config = KeyboardTeleopConfig()


### PR DESCRIPTION
Calibration saved to /home/mech-user/.cache/huggingface/lerobot/calibration/robots/xlerobot/None.json [MAIN] Successfully connected to robot
Traceback (most recent call last):
  File "/home/mech-user/venv_lerobot/lerobot/examples/4_xlerobot_teleop_keyboard.py", line 484, in <module>
    main()
  File "/home/mech-user/venv_lerobot/lerobot/examples/4_xlerobot_teleop_keyboard.py", line 407, in main
    _init_rerun(session_name="xlerobot_teleop_v2")
    ^^^^^^^^^^^
NameError: name '_init_rerun' is not defined. Did you mean: 'init_rerun'?