### PR TITLE
Resolve XLEVR_PATH from __file__ instead of a hardcoded path

### DIFF
--- a/XLeVR/vr_monitor.py
+++ b/XLeVR/vr_monitor.py
@@ -16,8 +16,9 @@ import socket
 from pathlib import Path
 from typing import Optional
 
-# Set the absolute path to the xlevr folder
-XLEVR_PATH = "/home/vec/lerobot/new/XLeVR"
+# Set the absolute path to the xlevr folder.
+# Resolved from this file so a fresh clone runs without editing it.
+XLEVR_PATH = os.path.dirname(os.path.abspath(__file__))
 
 def setup_xlevr_environment():
     """Setup xlevr environment"""


### PR DESCRIPTION
## TL;DR

`XLEVR_PATH` is pinned to `/home/vec/lerobot/new/XLeVR`, so a fresh clone has to edit `vr_monitor.py` before anything runs — otherwise `main()` prints `❌ XLeVR path does not exist: /home/vec/lerobot/new/XLeVR` and returns. This derives the path from `__file__`.

## Why

`setup_xlevr_environment()` uses this value for `sys.path`, `os.chdir` and `PYTHONPATH`. `XLeVR/` is exactly the directory `vr_monitor.py` lives in, so `__file__` produces the value the hardcoded string was meant to hold.

`config.yaml`, `cert.pem`, `key.pem` and `web-ui/` are opened relative to the working directory after the `chdir`, so they keep resolving as before. `os` is already imported at line 7.

Copying `vr_monitor.py` into another project keeps working the way the README describes: the copy points at its own directory.

## Tests

Imported the module from a clone at an unrelated path and confirmed `XLEVR_PATH` lands on that clone's `XLeVR/` with `config.yaml` under it.

Started `vr_monitor.py` on macOS and on a Raspberry Pi 5. Both serve `200` on HTTPS 8443 and `426 Upgrade Required` on 8442, with no error lines.