### PR TITLE
Document the real-robot VR teleop instead of a coming-soon note

### DIFF
--- a/docs/en/source/software/getting_started/XLeRobot_teleop.md
+++ b/docs/en/source/software/getting_started/XLeRobot_teleop.md
@@ -39,4 +39,17 @@ Intuitive gamepad control for the full XLeRobot system. Run [5_xlerobot_teleop_x
 
 ### VR Teleop
 
-You can try [controlling XLeRobot with VR in simulation](https://xlerobot.readthedocs.io/en/latest/simulation/getting_started/vr_sim.html) first. The offical code for VR teleop the real robot is coming soon. 
+You can try [controlling XLeRobot with VR in simulation](https://xlerobot.readthedocs.io/en/latest/simulation/getting_started/vr_sim.html) first.
+
+For the real robot, run [8_xlerobot_teleop_vr.py](https://github.com/Vector-Wangel/XLeRobot/blob/main/software/examples/8_xlerobot_teleop_vr.py). Both arms follow the controllers, the trigger drives the gripper, and the right thumbstick drives the base. There is also a `Teleoperator` subclass at [software/src/teleporators/xlerobot_vr](https://github.com/Vector-Wangel/XLeRobot/tree/main/software/src/teleporators/xlerobot_vr) that follows the `teleop_keyboard` format.
+
+The script starts [XLeVR](https://github.com/Vector-Wangel/XLeRobot/tree/main/XLeVR) inside its own process, so the headset connects to whichever machine runs the example. Four things to set up first:
+
+- put the `XLeVR` directory itself on `PYTHONPATH`, so `from vr_monitor import VRMonitor` resolves
+- install `pygame`, `scipy` and `websockets` into the same environment as `lerobot`
+- pass `id` and the serial ports to `XLerobotConfig()`. Without `id` the calibration file is looked up as `None.json`, and `connect()` starts the 17-motor interactive calibration instead of restoring the saved one
+- regenerate `cert.pem` / `key.pem`. The bundled certificate expired on 2026-06-27 and carries no `subjectAltName`. Deleting them does not help, because the HTTPS server starts before the WebSocket server and is the only one that does not call `ensure_ssl_certificates`
+
+In the headset browser, accept the certificate for **both** `https://<host>:8443` (web UI) and `https://<host>:8442` (WebSocket). `vr_app.js` hardcodes port 8442, and accepting 8443 alone leaves the WebSocket silently unable to connect.
+
+Tested on a real XLeRobot (dual SO-101 arms, head pan-tilt, 3-wheel omni base) driven from a Raspberry Pi 5 with a Quest 3S.

--- a/docs/zh/source/software/getting_started/XLeRobot_teleop.md
+++ b/docs/zh/source/software/getting_started/XLeRobot_teleop.md
@@ -37,4 +37,17 @@
 
 ### 8. VR遥操作
 
-您可以先尝试[在仿真中用VR控制XLeRobot](https://xlerobot.readthedocs.io/en/latest/simulation/getting_started/vr_sim.html)。真实机器人的VR遥操作官方代码即将推出。
+您可以先尝试[在仿真中用VR控制XLeRobot](https://xlerobot.readthedocs.io/en/latest/simulation/getting_started/vr_sim.html)。
+
+真实机器人请运行 [8_xlerobot_teleop_vr.py](https://github.com/Vector-Wangel/XLeRobot/blob/main/software/examples/8_xlerobot_teleop_vr.py)。双臂跟随手柄，扳机控制夹爪，右摇杆驱动底盘。[software/src/teleporators/xlerobot_vr](https://github.com/Vector-Wangel/XLeRobot/tree/main/software/src/teleporators/xlerobot_vr) 还提供了遵循 `teleop_keyboard` 格式的 `Teleoperator` 子类。
+
+该脚本会在自己的进程内启动 [XLeVR](https://github.com/Vector-Wangel/XLeRobot/tree/main/XLeVR)，因此头显连接的是运行该示例的那台机器。运行前需要准备四点：
+
+- 把 `XLeVR` 目录本身加入 `PYTHONPATH`，否则 `from vr_monitor import VRMonitor` 无法解析
+- 在与 `lerobot` 相同的环境中安装 `pygame`、`scipy` 和 `websockets`
+- 给 `XLerobotConfig()` 传入 `id` 和串口路径。不传 `id` 时标定文件会被当作 `None.json` 查找，`connect()` 会启动 17 个舵机的交互式标定，而不是恢复已保存的标定
+- 重新生成 `cert.pem` / `key.pem`。仓库自带的证书已于 2026-06-27 过期且没有 `subjectAltName`。删除它们也没用，因为 HTTPS 服务器先于 WebSocket 服务器启动，而它并不调用 `ensure_ssl_certificates`
+
+在头显浏览器中需要**分别**信任 `https://<host>:8443`（网页界面）和 `https://<host>:8442`（WebSocket）两个证书。`vr_app.js` 中写死了端口 8442，只信任 8443 会导致 WebSocket 静默连接失败。
+
+已在真实 XLeRobot（双 SO-101 机械臂、云台头部、三轮全向底盘）上验证，由 Raspberry Pi 5 驱动，头显为 Quest 3S。


### PR DESCRIPTION
## TL;DR

The VR Teleop section still reads "The offical code for VR teleop the real robot is coming soon", but `8_xlerobot_teleop_vr.py` landed in `91cd28b` (2025-09-13) and the `Teleoperator` subclass under `software/src/teleporators/xlerobot_vr` in `302a776` (2025-11-05). This replaces the placeholder with what the script drives and the four setup steps that reading it does not reveal.

**Files to review (2, +28 / -2):**

| File | Why |
|---|---|
| `docs/en/source/software/getting_started/XLeRobot_teleop.md` *(start here)* | The wording lives here |
| `docs/zh/source/software/getting_started/XLeRobot_teleop.md` | Same change, translated |

## Why

This page was last touched on 2025-10-14, a month after the VR code landed. Readers get sent to the simulation page and away from code that runs.

## Reviewer notes

- **`PYTHONPATH` has to point at `XLeVR` itself.** The example does `from vr_monitor import VRMonitor`, and `vr_monitor.py` sits directly in `XLeVR/`. Passing the parent directory gives `ModuleNotFoundError: No module named 'vr_monitor'`.
- **The bundled certificate expired on 2026-06-27** and carries no `subjectAltName`. Deleting `cert.pem` / `key.pem` does not regenerate them: `SimpleHTTPSServer.start()` runs before `VRWebSocketServer.start()` and calls `load_cert_chain` directly, while `ensure_ssl_certificates` only sits on the WebSocket side.
- **Port 8442 needs its own certificate exception.** `vr_app.js` hardcodes the WebSocket port, so a headset that trusts only 8443 loads the page and tracks controllers while nothing reaches the robot — nothing appears on the server side either.
- **`XLerobotConfig()` without `id`** resolves the calibration file to `None.json`, and `connect()` then starts the 17-motor interactive calibration instead of restoring the saved one.

## Tests

Ran the flow end to end on a real XLeRobot — dual SO-101 arms, head pan-tilt, 3-wheel omni base — driven from a Raspberry Pi 5 with a Quest 3S. Arms follow the controllers, the trigger drives the gripper, and the right thumbstick drives the base.